### PR TITLE
Update maven shade plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,8 +10,8 @@
     <packaging>jar</packaging>
 
     <properties>
-    <!--maven-shade-plugin does not support JDK 16 :c-->
-        <java.version>15</java.version>
+    <!--maven-shade-plugin 3.2.x does not support JDK 16 :c-->
+        <java.version>16</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
 
@@ -25,6 +25,13 @@
             <url>https://oss.sonatype.org/content/repositories/snapshots/</url>
         </repository>
     </repositories>
+
+    <pluginRepositories>
+        <pluginRepository>
+            <id>apache.snapshots</id>
+            <url>https://repository.apache.org/snapshots/</url>
+        </pluginRepository>
+    </pluginRepositories>
 
     <dependencies>
         <dependency>
@@ -69,7 +76,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.2.4</version>
+                <version>3.3.0-SNAPSHOT</version>
                 <configuration>
                     <relocations>
                         <!--

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,6 @@
     <packaging>jar</packaging>
 
     <properties>
-    <!--maven-shade-plugin 3.2.x does not support JDK 16 :c-->
         <java.version>16</java.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>


### PR DESCRIPTION
- Update maven shade plugin to 3.3.0 with complete support of jdk 16